### PR TITLE
Add claims

### DIFF
--- a/charts/uptime-probe/Chart.yaml
+++ b/charts/uptime-probe/Chart.yaml
@@ -1,3 +1,3 @@
 description: Probe to check uptime of external web sites.
 name: uptime-probe
-version: v0.2.1
+version: v0.3.0

--- a/charts/uptime-probe/Chart.yaml
+++ b/charts/uptime-probe/Chart.yaml
@@ -1,3 +1,3 @@
 description: Probe to check uptime of external web sites.
 name: uptime-probe
-version: v0.2.0
+version: v0.2.1

--- a/charts/uptime-probe/templates/configmap.yaml
+++ b/charts/uptime-probe/templates/configmap.yaml
@@ -7,19 +7,4 @@ data:
     period: 300
     port: {{ .Values.port }}
     sites:
-    - url: "https://polkadot.network"
-      needles: []
-    - url: "https://web3.foundation/"
-      needles: []
-    - url: "https://research.web3.foundation/en/latest/"
-      needles: []
-    - url: "https://wiki.web3.foundation/en/latest/"
-      needles: []
-    - url: "https://wiki.polkadot.network/en/latest/"
-      needles: []
-    - url: "https://riot.w3f.tech/"
-      needles: []
-    - url: "https://web3.foundation/.well-known/matrix/server"
-      needles: []
-    - url: "https://kusama.network"
-      needles: []
+{{ toYaml .Values.sites | indent 4 }}

--- a/charts/uptime-probe/values.yaml
+++ b/charts/uptime-probe/values.yaml
@@ -23,3 +23,5 @@ sites:
   needles: []
 - url: "https://kusama.network"
   needles: []
+- url: "https://claims.polkadot.network"
+  needles: []

--- a/charts/uptime-probe/values.yaml
+++ b/charts/uptime-probe/values.yaml
@@ -5,3 +5,21 @@ port: 8080
 image:
   repo: web3f/uptime-probe
   tag: latest
+
+sites:
+- url: "https://polkadot.network"
+  needles: []
+- url: "https://web3.foundation/"
+  needles: []
+- url: "https://research.web3.foundation/en/latest/"
+  needles: []
+- url: "https://wiki.web3.foundation/en/latest/"
+  needles: []
+- url: "https://wiki.polkadot.network/en/latest/"
+  needles: []
+- url: "https://riot.w3f.tech/"
+  needles: []
+- url: "https://web3.foundation/.well-known/matrix/server"
+  needles: []
+- url: "https://kusama.network"
+  needles: []


### PR DESCRIPTION
Adds https://claims.polkadot.network to be watched by the uptime probe. Also moves the config settings with the sites to be watched to the chart's values.