### PR TITLE
Redeploy

### DIFF
--- a/charts/uptime-probe/Chart.yaml
+++ b/charts/uptime-probe/Chart.yaml
@@ -1,4 +1,4 @@
 description: Probe to check uptime of external web sites.
 name: uptime-probe
-version: v0.4.1
+version: v0.4.2
 apiVersion: v2


### PR DESCRIPTION
Closes https://github.com/w3f/infrastructure/issues/144

We didn't redeploy after recreating prometheus bcc of the switch to helm3, currently the servicemonitor for uptime-probe is missing and prometheus is not scrapping it. Probably the same reason for the issues in https://github.com/w3f/infrastructure/issues/117